### PR TITLE
Remove sensitive npm token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ Desktop.ini
 /*.exe
 /*.apk
 /*_DoNotShip
+
+# Ignore npm configuration files
+*.npmrc

--- a/Packages/Bubbles/.npmrc.example
+++ b/Packages/Bubbles/.npmrc.example
@@ -1,0 +1,2 @@
+@JaimeCamachoDev:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=

--- a/Packages/Bubbles/Bubbles.npmrc
+++ b/Packages/Bubbles/Bubbles.npmrc
@@ -1,2 +1,0 @@
-@JaimeCamachoDev:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=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

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ _**Sistema de burbujas animadas empaquetadas en una flipbook sheet desde Houdini
 
 
 </header>
+
+## Configuracion de npm
+Copia `.npmrc.example` a `.npmrc` y proporciona un `NODE_AUTH_TOKEN` o token personal para acceder a los paquetes privados.
+
    
 <footer>
    


### PR DESCRIPTION
## Summary
- remove `Bubbles.npmrc` containing auth token
- ignore future `*.npmrc` files
- provide `.npmrc.example` as template
- document how to configure npm authentication

## Testing
- `npm --version`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_685aa8487304832681088545b56eacc5