### PR TITLE
Add Unity installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,32 @@ _**Sistema de burbujas animadas empaquetadas en una flipbook sheet desde Houdini
 ## Configuracion de npm
 Copia `.npmrc.example` a `.npmrc` y proporciona un `NODE_AUTH_TOKEN` o token personal para acceder a los paquetes privados.
 
+## Configuración en Unity
+Agrega la GitHub Package Registry en `Packages/manifest.json` de tu proyecto para obtener este paquete:
+
+```json
+{
+  "scopedRegistries": [
+    {
+      "name": "GitHub",
+      "url": "https://npm.pkg.github.com",
+      "scopes": [
+        "@JaimeCamachoDev"
+      ]
+    }
+  ],
+  "dependencies": {
+    "@JaimeCamachoDev/bubbles": "1.0.0"
+  }
+}
+```
+
+Para autenticarte en la registry de GitHub, crea un _Personal Access Token_ con el permiso `read:packages` en [Developer settings](https://github.com/settings/tokens) y guárdalo en un archivo `.npmrc` local:
+
+```bash
+//npm.pkg.github.com/:_authToken=<TOKEN_PERSONAL>
+```
+
    
 <footer>
    


### PR DESCRIPTION
## Summary
- explain how to add the GitHub scoped registry in Unity's manifest.json
- show how to add @JaimeCamachoDev/bubbles dependency
- add example for storing a personal access token in `.npmrc`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_685aaa52e368832682b8fe34db0107fe