### PR TITLE
Configure GitHub Packages for Unity package

### DIFF
--- a/Packages/com.jaimecamacho.bubbles/.npmrc.example
+++ b/Packages/com.jaimecamacho.bubbles/.npmrc.example
@@ -1,0 +1,2 @@
+@JaimeCamachoDev:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=

--- a/Packages/com.jaimecamacho.bubbles/README.md
+++ b/Packages/com.jaimecamacho.bubbles/README.md
@@ -1,15 +1,33 @@
 # Bubbles
 
-**Bubbles** es un sistema modular de partículas tipo burbuja para Unity 6.  
-Diseñado para integrarse fácilmente como paquete y usarse en múltiples proyectos.
+**Bubbles** es un sistema modular de partículas tipo burbuja para Unity. Se
+diseñó para integrarse como paquete y reutilizarse en distintos proyectos.
 
-## 📦 Instalación
+## 📦 Instalación desde GitHub Packages
 
-Agrega esto a tu `manifest.json`:
+1. Copia `.npmrc.example` a `.npmrc` y añade tu `NODE_AUTH_TOKEN` personal para
+   poder acceder al registro privado.
+2. En `Packages/manifest.json` declara la registry y la dependencia:
 
 ```json
-"com.jaimecamacho.bubbles": "https://github.com/JaimeCamachoDev/Bubbles.git?path=/Packages/com.jaimecamacho.bubbles#v1.0.0"
+{
+  "scopedRegistries": [
+    {
+      "name": "GitHub",
+      "url": "https://npm.pkg.github.com",
+      "scopes": [
+        "JaimeCamachoDev"
+      ]
+    }
+  ],
+  "dependencies": {
+    "@JaimeCamachoDev/bubbles": "1.0.0"
+  }
+}
 ```
+
+Al reiniciar Unity, el Package Manager descargará la versión indicada desde
+GitHub.
 
 ## ✨ Uso básico
 
@@ -20,6 +38,6 @@ emitter.Emit();
 
 ## 📂 Carpetas
 
-- `Runtime`: scripts que se usan en el juego
-- `Editor`: extensiones del editor (inspector, menú, etc)
-- `Documentation~`: documentación visible en el Package Manager
+- `Runtime`: scripts de tiempo de ejecución
+- `Editor`: utilidades para el Editor
+- `Documentation~`: documentación mostrada en el Package Manager

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -5,7 +5,8 @@
     "com.unity.vfx-toolbox": "https://github.com/Unity-Technologies/VFXToolbox.git",
     "jp.keijiro.klutter-tools": "2.1.0",
     "com.unity.modules.animation": "1.0.0",
-    "com.unity.modules.particlesystem": "1.0.0"
+    "com.unity.modules.particlesystem": "1.0.0",
+    "@JaimeCamachoDev/bubbles": "1.0.0"
   },
   "scopedRegistries": [
     {
@@ -13,6 +14,13 @@
       "url": "https://registry.npmjs.com",
       "scopes": [
         "jp.keijiro"
+      ]
+    },
+    {
+      "name": "GitHub",
+      "url": "https://npm.pkg.github.com",
+      "scopes": [
+        "JaimeCamachoDev"
       ]
     }
   ]

--- a/README.md
+++ b/README.md
@@ -6,9 +6,33 @@
 
 _**Sistema de burbujas animadas empaquetadas en una flipbook sheet desde Houdini mediante VFX Toolbox. Ideal para simular efectos de burbujeo continuo en líquidos o ambientes submarinos.**_
 
-
 </header>
 
+## Configuracion de npm
+Copia `Packages/com.jaimecamacho.bubbles/.npmrc.example` a `.npmrc` y coloca tu `NODE_AUTH_TOKEN` o token personal para acceder a GitHub Packages.
+
+## Instalacion del paquete
+Incluye el registro y la dependencia en `Packages/manifest.json` de tu proyecto:
+
+```json
+{
+  "scopedRegistries": [
+    {
+      "name": "GitHub",
+      "url": "https://npm.pkg.github.com",
+      "scopes": [
+        "JaimeCamachoDev"
+      ]
+    }
+  ],
+  "dependencies": {
+    "@JaimeCamachoDev/bubbles": "1.0.0"
+  }
+}
+```
+
+Al reiniciar Unity, el Package Manager descargara la version indicada desde GitHub.
+
 <footer>
-   
+
 </footer>


### PR DESCRIPTION
## Summary
- document how to install the package from GitHub Packages
- add example `.npmrc` file for authentication
- register the GitHub scoped registry and dependency in `manifest.json`

## Testing
- `npm pack --dry-run`

------
https://chatgpt.com/codex/tasks/task_b_685a88f01c208326b57ca69a09ef06ad